### PR TITLE
The existing bug fixes and consideration of CloudWatch Logs quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ Use this dependency in your Java/Mule Applications
 	<CLOUDW name="CloudW" logGroupName="<your CloudWatch group name>"
 		logStreamName="<your Mule app name>-${sys:environment}"
 		awsAccessKey="<your AWS access key>" 
-        awsSecretKey="<your AWS secret key>"
+		awsSecretKey="<your AWS secret key>"
 		awsRegion="<your AWS region>" 
 		endpoint="<your CloudWatch VPC Endpoint>" 
 		messagesBatchSize="5"
-		queueLength="100">
+		queueLength="100"
+		retryCount="<your retry count when the error occurs (default 2)>"
+		retrySleepMSec="<your sleep millisecond when the error occurs (default 5000)>"/>
+		logsQuotasSizeCheck="<your logs quotas size check (default false)>"/>
 		<PatternLayout
 			pattern="%-5p %d [%t] %X{correlationId}%c: %m%n" /> 
 	</CLOUDW>
@@ -69,6 +72,51 @@ Add this custom appender to your Root logger in log4j2.xml.
 </AsyncRoot>
 ```
 
+* Configure AWS credential
+
+When the AWS credential by environment variables or configuration and credential file settings is defined, awsAccessKey, awsSecretKey, awsRegion is not required but when use endpoint, awsRegion is required.
+
+* Implementation of log4j2-cloudwatch-appender against CloudWatch Logs quotas
+  * If logsQuotasSizeCheck is true
+    * When the log message size exceeds max event size 256KB, the log message is skipped. When the send total byte size of log messages exceeds batch max size 1MB, part of the log messages is sent and the rest is sent next regardless of messagesBatchSize.
+  * If logsQuotasSizeCheck is false
+    * When the log message size exceeds max event size 256KB, the exception occurred and no log output. When the send total byte size of log messages exceeds batch max size 1MB, the exception occurred and no log output.
+
 * That's it!
 
 When you run the project with this appender added with your AWS credentials, you should see your app log events flowing into the configured CloudWatch group/logStreamName.
+
+The important points
+==========================
+When your web application use in MuleSoft CloudHub using multiple workers, it is recommended highly to define the log stream for <b>each worker</b> as shown below for avoiding the InvalidSequenceToken errors and the total PutLogEvents request of each worker is <b>limited to 5 per second per log stream</b>. It is recommended to define similarly for other multi-server system. 
+
+
+1. log4j2.xml (extract)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MuleSoft CloudHub  
+   (The worker.id is CloudHub Reserved Property.)
+```  
+<CLOUDW name="CloudW" logGroupName="testGroup"
+          logStreamName="testStreamWorker${sys:worker.id}"
+```
+
+2. log4j2.xml (extract)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Other multi-server system etc
+```  
+<CLOUDW name="CloudW" logGroupName="testGroup"
+          logStreamName="testStreamHost${env:host.id}"
+```
+
+3. CloudWatch Logs Insights sample
+```
+fields @logStream, @timestamp, @message
+| filter @logStream like "testStreamWorker"
+| sort @timestamp desc
+| limit 20
+```
+
+
+## References
+-  [CloudWatch Logs quotas](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).
+-  [How do I troubleshoot InvalidSequenceToken errors in the Cloudwatch logs?](https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-invalid-sequence-token/?nc1=h_ls)
+-  [CloudHub Reserved Properties](https://help.mulesoft.com/s/article/CloudHub-Reserved-Properties)
+-  [Environment variables to configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
+-  [Using the AWS SDK for Java (Working with AWS Credentials)](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html)
+-  [AWS SDKs and Tools (AWS Region)](https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<aws.sdk.version>1.11.737</aws.sdk.version>
-		<log4j.version>2.13.1</log4j.version>
+		<log4j.version>2.18.0</log4j.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<aws.sdk.version>1.11.737</aws.sdk.version>
+		<aws.sdk.version>1.12.125</aws.sdk.version>
 		<log4j.version>2.18.0</log4j.version>
 	</properties>
 	<dependencies>

--- a/src/main/java/com/java/javacodegeeks/log4j2/cloudwatch/CloudwatchAppender.java
+++ b/src/main/java/com/java/javacodegeeks/log4j2/cloudwatch/CloudwatchAppender.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
@@ -108,7 +109,7 @@ public class CloudwatchAppender extends AbstractAppender {
                                Integer messagesBatchSize,
                                String endpoint
     ) {
-        super(name, filter, layout, ignoreExceptions);
+        super(name, filter, layout, ignoreExceptions, Property.EMPTY_ARRAY);
         this.logGroupName = logGroupName;
         this.logStreamName = logStreamName;
         this.awsAccessKey = awsAccessKey;

--- a/src/main/java/com/java/javacodegeeks/log4j2/cloudwatch/CloudwatchAppender.java
+++ b/src/main/java/com/java/javacodegeeks/log4j2/cloudwatch/CloudwatchAppender.java
@@ -137,11 +137,15 @@ public class CloudwatchAppender extends AbstractAppender {
         } else {
             //Credentials management could be customized
             com.amazonaws.services.logs.AWSLogsClientBuilder clientBuilder = com.amazonaws.services.logs.AWSLogsClientBuilder.standard();
-            clientBuilder.setCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(this.awsAccessKey, this.awsAccessSecret)));
+            if (!isBlank(this.awsAccessKey) && !isBlank(this.awsAccessSecret)) {
+                clientBuilder.setCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(this.awsAccessKey, this.awsAccessSecret)));
+            }
             if (this.endpoint != null) {
                 clientBuilder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(this.endpoint, this.awsRegion));
             } else {
-                clientBuilder.withRegion(Regions.fromName(awsRegion));
+                if (!isBlank(awsRegion)) {
+                    clientBuilder.withRegion(Regions.fromName(awsRegion));
+                }
             }
             this.awsLogsClient = clientBuilder.build();
             loggingEventsQueue = new LinkedBlockingQueue<>(queueLength);

--- a/src/main/java/com/java/javacodegeeks/log4j2/cloudwatch/CloudwatchAppender.java
+++ b/src/main/java/com/java/javacodegeeks/log4j2/cloudwatch/CloudwatchAppender.java
@@ -38,293 +38,293 @@ import com.amazonaws.services.logs.model.InvalidSequenceTokenException;
 import com.amazonaws.services.logs.model.PutLogEventsRequest;
 import com.amazonaws.services.logs.model.PutLogEventsResult;
 import com.amazonaws.client.builder.AwsClientBuilder;
- 
+
 @Plugin(name = "CLOUDW", category = "Core", elementType = "appender", printObject = true)
 public class CloudwatchAppender extends AbstractAppender {
-	  
-	 /**
-	  * 
-	  */
-	 private static final long serialVersionUID = 12321345L;
-	  
-	 private static Logger logger2 = LogManager.getLogger(CloudwatchAppender.class);
-	 
-	 private final Boolean DEBUG_MODE = System.getProperty("log4j.debug") != null;
-	 
-	    /**
-	     * Used to make sure that on close() our daemon thread isn't also trying to sendMessage()s
-	     */
-	    private Object sendMessagesLock = new Object();
-	 
-	    /**
-	     * The queue used to buffer log entries
-	     */
-	    private LinkedBlockingQueue<LogEvent> loggingEventsQueue;
-	 
-	    /**
-	     * the AWS Cloudwatch Logs API client
-	     */
-	    private AWSLogs awsLogsClient;
-	 
-	    private AtomicReference lastSequenceToken = new AtomicReference<>();
-	 
-	    /**
-	     * The AWS Cloudwatch Log group name
-	     */
-	    private String logGroupName;
-	 
-	    /**
-	     * The AWS Cloudwatch Log stream name
-	     */
-	    private String logStreamName;
-	 
-	    /**
-	     * The queue / buffer size
-	     */
-	    private int queueLength = 1024;
-	    
-	    private String awsAccessKey;
-	    private String awsAccessSecret;
-	    private String awsRegion;
-	    private String endpoint;
-	 
-	    /**
-	     * The maximum number of log entries to send in one go to the AWS Cloudwatch Log service
-	     */
-	    private int messagesBatchSize = 128;
-	 
-	    private AtomicBoolean cloudwatchAppenderInitialised = new AtomicBoolean(false);
-	  
-	 
-	    private CloudwatchAppender(final String name,
-	                           final Layout layout,
-	                           final Filter filter,
-	                           final boolean ignoreExceptions,String logGroupName, 
-	                           String logStreamName,
-	                           final String awsAccessKey,
-	                           final String awsSecretKey,
-	                           final String awsRegion,
-	                           Integer queueLength,
-	                           Integer messagesBatchSize,
-	                           String endpoint
-	                           ) {
-	        super(name, filter, layout, ignoreExceptions);
-	        this.logGroupName = logGroupName;
-	        this.logStreamName = logStreamName;
-	        this.awsAccessKey = awsAccessKey;
-	        this.awsAccessSecret = awsSecretKey;
-	        this.awsRegion = awsRegion;
-	        this.queueLength = queueLength;
-	        this.messagesBatchSize = messagesBatchSize;
-	        this.endpoint = endpoint;
-	        this.activateOptions();
-	    }
-	 
-	    @Override
-	    public void append(LogEvent event) {
-	      if (cloudwatchAppenderInitialised.get()) {
-	             loggingEventsQueue.offer(event.toImmutable());
-	         } else {
-	             // just do nothing
-	         }
-	    }
-	     
-	    public void activateOptions() {
-	        if (isBlank(logGroupName) || isBlank(logStreamName)) {
-	            logger2.error("Could not initialise CloudwatchAppender because either or both LogGroupName(" + logGroupName + ") and LogStreamName(" + logStreamName + ") are null or empty");
-	            this.stop();
-	        } else {
-	            //Credentials management could be customized
-	            com.amazonaws.services.logs.AWSLogsClientBuilder clientBuilder = com.amazonaws.services.logs.AWSLogsClientBuilder.standard();
-	            clientBuilder.setCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(this.awsAccessKey, this.awsAccessSecret)));
-	            if (this.endpoint != null) {
-	                 clientBuilder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(this.endpoint, this.awsRegion));
-	            } else {
-	                 clientBuilder.withRegion(Regions.fromName(awsRegion));
-	            }
-	            this.awsLogsClient = clientBuilder.build();
-	            loggingEventsQueue = new LinkedBlockingQueue<>(queueLength);
-	            try {
-	                initializeCloudwatchResources();
-	                initCloudwatchDaemon();
-	                cloudwatchAppenderInitialised.set(true);
-	            } catch (Exception e) {
-	                logger2.error("Could not initialise Cloudwatch Logs for LogGroupName: " + logGroupName + " and LogStreamName: " + logStreamName, e);
-	                if (DEBUG_MODE) {
-	                    System.err.println("Could not initialise Cloudwatch Logs for LogGroupName: " + logGroupName + " and LogStreamName: " + logStreamName);
-	                    e.printStackTrace();
-	                }
-	            }
-	        }
-	    }
-	     
-	    private void initCloudwatchDaemon() {
-	     Thread t = new Thread(() -> {
-	            while (true) {
-	                try {
-	                    if (loggingEventsQueue.size() > 0) {
-	                        sendMessages();
-	                    }
-	                    Thread.currentThread().sleep(20L);
-	                } catch (InterruptedException e) {
-	                    if (DEBUG_MODE) {
-	                        e.printStackTrace();
-	                    }
-	                }
-	            }
-	        });
-	     t.setName("CloudwatchThread");
-	     t.setDaemon(true);
-	     t.start();
-	    }
-	     
-	    private void sendMessages() {
-	        synchronized (sendMessagesLock) {
-	            LogEvent polledLoggingEvent;
-	            final Layout layout = getLayout();
-	            List<LogEvent> loggingEvents = new ArrayList<>();
-	 
-	            try {
-	 
-	                while ((polledLoggingEvent = (LogEvent) loggingEventsQueue.poll()) != null && loggingEvents.size() <= messagesBatchSize) {
-	                    loggingEvents.add(polledLoggingEvent);
-	                }
-	               
-	                List inputLogEvents = loggingEvents.stream()
-	                        .map(loggingEvent -> new InputLogEvent().withTimestamp(loggingEvent.getTimeMillis())
-	                          .withMessage
-	                          (
-	                            layout == null ?
-	                            loggingEvent.getMessage().getFormattedMessage():
-	                            new String(layout.toByteArray(loggingEvent), StandardCharsets.UTF_8)
-	                            )
-	                          )
-	                        .sorted(comparing(InputLogEvent::getTimestamp))
-	                        .collect(toList());
-	 
-	                if (!inputLogEvents.isEmpty()) {
-	
-	                
-	                    PutLogEventsRequest putLogEventsRequest = new PutLogEventsRequest(
-	                            logGroupName,
-	                            logStreamName,
-	                            inputLogEvents);
-	 
-	                    try {
-	                        putLogEventsRequest.setSequenceToken((String)lastSequenceToken.get());
-	                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
-	                        lastSequenceToken.set(result.getNextSequenceToken());
-	                    } catch (DataAlreadyAcceptedException dataAlreadyAcceptedExcepted) {
-	                      
-	                        putLogEventsRequest.setSequenceToken(dataAlreadyAcceptedExcepted.getExpectedSequenceToken());
-	                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
-	                        lastSequenceToken.set(result.getNextSequenceToken());
-	                        if (DEBUG_MODE) {
-	                            dataAlreadyAcceptedExcepted.printStackTrace();
-	                        }
-	                    } catch (InvalidSequenceTokenException invalidSequenceTokenException) {
-	                        putLogEventsRequest.setSequenceToken(invalidSequenceTokenException.getExpectedSequenceToken());
-	                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
-	                        lastSequenceToken.set(result.getNextSequenceToken());
-	                        if (DEBUG_MODE) {
-	                            invalidSequenceTokenException.printStackTrace();
-	                        }
-	                    }
-	                }
-	            } catch (Exception e) {
-	                if (DEBUG_MODE) {
-	                 logger2.error(" error inserting cloudwatch:",e);
-	                    e.printStackTrace();
-	                }
-	            }
-	        }
-	    }
-	 
-	    private void initializeCloudwatchResources() {
-	 
-	        DescribeLogGroupsRequest describeLogGroupsRequest = new DescribeLogGroupsRequest();
-	        describeLogGroupsRequest.setLogGroupNamePrefix(logGroupName);
-	 
-	        Optional logGroupOptional = awsLogsClient
-	                .describeLogGroups(describeLogGroupsRequest)
-	                .getLogGroups()
-	                .stream()
-	                .filter(logGroup -> logGroup.getLogGroupName().equals(logGroupName))
-	                .findFirst();
-	 
-	        if (!logGroupOptional.isPresent()) {
-	            CreateLogGroupRequest createLogGroupRequest = new CreateLogGroupRequest().withLogGroupName(logGroupName);
-	            awsLogsClient.createLogGroup(createLogGroupRequest);
-	        }
-	 
-	        DescribeLogStreamsRequest describeLogStreamsRequest = new DescribeLogStreamsRequest().withLogGroupName(logGroupName).withLogStreamNamePrefix(logStreamName);
-	 
-	        Optional logStreamOptional = awsLogsClient
-	                .describeLogStreams(describeLogStreamsRequest)
-	                .getLogStreams()
-	                .stream()
-	                .filter(logStream -> logStream.getLogStreamName().equals(logStreamName))
-	                .findFirst();
-	        if (!logStreamOptional.isPresent()) {
-	            CreateLogStreamRequest createLogStreamRequest = new CreateLogStreamRequest().withLogGroupName(logGroupName).withLogStreamName(logStreamName);
-	            CreateLogStreamResult o = awsLogsClient.createLogStream(createLogStreamRequest);
-	        }
-	 
-	    }
-	     
-	    private boolean isBlank(String string) {
-	        return null == string || string.trim().length() == 0;
-	    }
-	    protected String getSimpleStacktraceAsString(final Throwable thrown) {
-	        final StringBuilder stackTraceBuilder = new StringBuilder();
-	        for (StackTraceElement stackTraceElement : thrown.getStackTrace()) {
-	            new Formatter(stackTraceBuilder).format("%s.%s(%s:%d)%n",
-	                    stackTraceElement.getClassName(),
-	                    stackTraceElement.getMethodName(),
-	                    stackTraceElement.getFileName(),
-	                    stackTraceElement.getLineNumber());
-	        }
-	        return stackTraceBuilder.toString();
-	    }
-	 
-	    @Override
-	    public void start() {
-	        super.start();
-	    }
-	 
-	    @Override
-	    public void stop() {
-	        super.stop();
-	        while (loggingEventsQueue != null && !loggingEventsQueue.isEmpty()) {
-	            this.sendMessages();
-	        }
-	    }
-	 
-	    @Override
-	    public String toString() {
-	        return CloudwatchAppender.class.getSimpleName() + "{"
-	                + "name=" + getName() + " loggroupName=" + logGroupName
-	                +" logstreamName=" + logStreamName;
-	                
-	    }
-	 
-	    @PluginFactory
-	    @SuppressWarnings("unused")
-	    public static CloudwatchAppender createCloudWatchAppender(
-	      @PluginAttribute(value = "queueLength" ) Integer queueLength,
-	                                                  @PluginElement("Layout") Layout layout,
-	                                                  @PluginAttribute(value = "logGroupName") String logGroupName,
-	                                                  @PluginAttribute(value = "logStreamName") String logStreamName,
-	                                                  @PluginAttribute(value = "awsAccessKey") String awsAccessKey,
-	                                                  @PluginAttribute(value = "awsSecretKey") String awsSecretKey,
-	                                                  @PluginAttribute(value = "awsRegion") String awsRegion,
-	                                                  @PluginAttribute(value = "name") String name,
-	                                                  @PluginAttribute(value = "ignoreExceptions", defaultBoolean = false) Boolean ignoreExceptions,
-	                                                   
-	                                                  @PluginAttribute(value = "messagesBatchSize") Integer messagesBatchSize,
-	                                                  @PluginAttribute(value = "endpoint") String endpoint
-	                                                  )
-	    {
-	     return new CloudwatchAppender(name, layout, null, ignoreExceptions, logGroupName, logStreamName , awsAccessKey, awsSecretKey, awsRegion, queueLength,messagesBatchSize,endpoint);
-	    }
-	}
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 12321345L;
+
+    private static Logger logger2 = LogManager.getLogger(CloudwatchAppender.class);
+
+    private final Boolean DEBUG_MODE = System.getProperty("log4j.debug") != null;
+
+    /**
+     * Used to make sure that on close() our daemon thread isn't also trying to sendMessage()s
+     */
+    private Object sendMessagesLock = new Object();
+
+    /**
+     * The queue used to buffer log entries
+     */
+    private LinkedBlockingQueue<LogEvent> loggingEventsQueue;
+
+    /**
+     * the AWS Cloudwatch Logs API client
+     */
+    private AWSLogs awsLogsClient;
+
+    private AtomicReference lastSequenceToken = new AtomicReference<>();
+
+    /**
+     * The AWS Cloudwatch Log group name
+     */
+    private String logGroupName;
+
+    /**
+     * The AWS Cloudwatch Log stream name
+     */
+    private String logStreamName;
+
+    /**
+     * The queue / buffer size
+     */
+    private int queueLength = 1024;
+
+    private String awsAccessKey;
+    private String awsAccessSecret;
+    private String awsRegion;
+    private String endpoint;
+
+    /**
+     * The maximum number of log entries to send in one go to the AWS Cloudwatch Log service
+     */
+    private int messagesBatchSize = 128;
+
+    private AtomicBoolean cloudwatchAppenderInitialised = new AtomicBoolean(false);
+
+
+    private CloudwatchAppender(final String name,
+                               final Layout layout,
+                               final Filter filter,
+                               final boolean ignoreExceptions, String logGroupName,
+                               String logStreamName,
+                               final String awsAccessKey,
+                               final String awsSecretKey,
+                               final String awsRegion,
+                               Integer queueLength,
+                               Integer messagesBatchSize,
+                               String endpoint
+    ) {
+        super(name, filter, layout, ignoreExceptions);
+        this.logGroupName = logGroupName;
+        this.logStreamName = logStreamName;
+        this.awsAccessKey = awsAccessKey;
+        this.awsAccessSecret = awsSecretKey;
+        this.awsRegion = awsRegion;
+        this.queueLength = queueLength;
+        this.messagesBatchSize = messagesBatchSize;
+        this.endpoint = endpoint;
+        this.activateOptions();
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (cloudwatchAppenderInitialised.get()) {
+            loggingEventsQueue.offer(event.toImmutable());
+        } else {
+            // just do nothing
+        }
+    }
+
+    public void activateOptions() {
+        if (isBlank(logGroupName) || isBlank(logStreamName)) {
+            logger2.error("Could not initialise CloudwatchAppender because either or both LogGroupName(" + logGroupName + ") and LogStreamName(" + logStreamName + ") are null or empty");
+            this.stop();
+        } else {
+            //Credentials management could be customized
+            com.amazonaws.services.logs.AWSLogsClientBuilder clientBuilder = com.amazonaws.services.logs.AWSLogsClientBuilder.standard();
+            clientBuilder.setCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(this.awsAccessKey, this.awsAccessSecret)));
+            if (this.endpoint != null) {
+                clientBuilder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(this.endpoint, this.awsRegion));
+            } else {
+                clientBuilder.withRegion(Regions.fromName(awsRegion));
+            }
+            this.awsLogsClient = clientBuilder.build();
+            loggingEventsQueue = new LinkedBlockingQueue<>(queueLength);
+            try {
+                initializeCloudwatchResources();
+                initCloudwatchDaemon();
+                cloudwatchAppenderInitialised.set(true);
+            } catch (Exception e) {
+                logger2.error("Could not initialise Cloudwatch Logs for LogGroupName: " + logGroupName + " and LogStreamName: " + logStreamName, e);
+                if (DEBUG_MODE) {
+                    System.err.println("Could not initialise Cloudwatch Logs for LogGroupName: " + logGroupName + " and LogStreamName: " + logStreamName);
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private void initCloudwatchDaemon() {
+        Thread t = new Thread(() -> {
+            while (true) {
+                try {
+                    if (loggingEventsQueue.size() > 0) {
+                        sendMessages();
+                    }
+                    Thread.currentThread().sleep(20L);
+                } catch (InterruptedException e) {
+                    if (DEBUG_MODE) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        });
+        t.setName("CloudwatchThread");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private void sendMessages() {
+        synchronized (sendMessagesLock) {
+            LogEvent polledLoggingEvent;
+            final Layout layout = getLayout();
+            List<LogEvent> loggingEvents = new ArrayList<>();
+
+            try {
+
+                while ((polledLoggingEvent = (LogEvent) loggingEventsQueue.poll()) != null && loggingEvents.size() <= messagesBatchSize) {
+                    loggingEvents.add(polledLoggingEvent);
+                }
+
+                List inputLogEvents = loggingEvents.stream()
+                        .map(loggingEvent -> new InputLogEvent().withTimestamp(loggingEvent.getTimeMillis())
+                                .withMessage
+                                        (
+                                                layout == null ?
+                                                        loggingEvent.getMessage().getFormattedMessage() :
+                                                        new String(layout.toByteArray(loggingEvent), StandardCharsets.UTF_8)
+                                        )
+                        )
+                        .sorted(comparing(InputLogEvent::getTimestamp))
+                        .collect(toList());
+
+                if (!inputLogEvents.isEmpty()) {
+
+
+                    PutLogEventsRequest putLogEventsRequest = new PutLogEventsRequest(
+                            logGroupName,
+                            logStreamName,
+                            inputLogEvents);
+
+                    try {
+                        putLogEventsRequest.setSequenceToken((String) lastSequenceToken.get());
+                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
+                        lastSequenceToken.set(result.getNextSequenceToken());
+                    } catch (DataAlreadyAcceptedException dataAlreadyAcceptedExcepted) {
+
+                        putLogEventsRequest.setSequenceToken(dataAlreadyAcceptedExcepted.getExpectedSequenceToken());
+                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
+                        lastSequenceToken.set(result.getNextSequenceToken());
+                        if (DEBUG_MODE) {
+                            dataAlreadyAcceptedExcepted.printStackTrace();
+                        }
+                    } catch (InvalidSequenceTokenException invalidSequenceTokenException) {
+                        putLogEventsRequest.setSequenceToken(invalidSequenceTokenException.getExpectedSequenceToken());
+                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
+                        lastSequenceToken.set(result.getNextSequenceToken());
+                        if (DEBUG_MODE) {
+                            invalidSequenceTokenException.printStackTrace();
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                if (DEBUG_MODE) {
+                    logger2.error(" error inserting cloudwatch:", e);
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private void initializeCloudwatchResources() {
+
+        DescribeLogGroupsRequest describeLogGroupsRequest = new DescribeLogGroupsRequest();
+        describeLogGroupsRequest.setLogGroupNamePrefix(logGroupName);
+
+        Optional logGroupOptional = awsLogsClient
+                .describeLogGroups(describeLogGroupsRequest)
+                .getLogGroups()
+                .stream()
+                .filter(logGroup -> logGroup.getLogGroupName().equals(logGroupName))
+                .findFirst();
+
+        if (!logGroupOptional.isPresent()) {
+            CreateLogGroupRequest createLogGroupRequest = new CreateLogGroupRequest().withLogGroupName(logGroupName);
+            awsLogsClient.createLogGroup(createLogGroupRequest);
+        }
+
+        DescribeLogStreamsRequest describeLogStreamsRequest = new DescribeLogStreamsRequest().withLogGroupName(logGroupName).withLogStreamNamePrefix(logStreamName);
+
+        Optional logStreamOptional = awsLogsClient
+                .describeLogStreams(describeLogStreamsRequest)
+                .getLogStreams()
+                .stream()
+                .filter(logStream -> logStream.getLogStreamName().equals(logStreamName))
+                .findFirst();
+        if (!logStreamOptional.isPresent()) {
+            CreateLogStreamRequest createLogStreamRequest = new CreateLogStreamRequest().withLogGroupName(logGroupName).withLogStreamName(logStreamName);
+            CreateLogStreamResult o = awsLogsClient.createLogStream(createLogStreamRequest);
+        }
+
+    }
+
+    private boolean isBlank(String string) {
+        return null == string || string.trim().length() == 0;
+    }
+
+    protected String getSimpleStacktraceAsString(final Throwable thrown) {
+        final StringBuilder stackTraceBuilder = new StringBuilder();
+        for (StackTraceElement stackTraceElement : thrown.getStackTrace()) {
+            new Formatter(stackTraceBuilder).format("%s.%s(%s:%d)%n",
+                    stackTraceElement.getClassName(),
+                    stackTraceElement.getMethodName(),
+                    stackTraceElement.getFileName(),
+                    stackTraceElement.getLineNumber());
+        }
+        return stackTraceBuilder.toString();
+    }
+
+    @Override
+    public void start() {
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        while (loggingEventsQueue != null && !loggingEventsQueue.isEmpty()) {
+            this.sendMessages();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return CloudwatchAppender.class.getSimpleName() + "{"
+                + "name=" + getName() + " loggroupName=" + logGroupName
+                + " logstreamName=" + logStreamName;
+
+    }
+
+    @PluginFactory
+    @SuppressWarnings("unused")
+    public static CloudwatchAppender createCloudWatchAppender(
+            @PluginAttribute(value = "queueLength") Integer queueLength,
+            @PluginElement("Layout") Layout layout,
+            @PluginAttribute(value = "logGroupName") String logGroupName,
+            @PluginAttribute(value = "logStreamName") String logStreamName,
+            @PluginAttribute(value = "awsAccessKey") String awsAccessKey,
+            @PluginAttribute(value = "awsSecretKey") String awsSecretKey,
+            @PluginAttribute(value = "awsRegion") String awsRegion,
+            @PluginAttribute(value = "name") String name,
+            @PluginAttribute(value = "ignoreExceptions", defaultBoolean = false) Boolean ignoreExceptions,
+
+            @PluginAttribute(value = "messagesBatchSize") Integer messagesBatchSize,
+            @PluginAttribute(value = "endpoint") String endpoint
+    ) {
+        return new CloudwatchAppender(name, layout, null, ignoreExceptions, logGroupName, logStreamName, awsAccessKey, awsSecretKey, awsRegion, queueLength, messagesBatchSize, endpoint);
+    }
+}


### PR DESCRIPTION
## Fixes

1. Fixed [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) security vulnerability.

2. Supports default credential by environment variables ([aws_secret_access_key, aws_access_key_id](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) and [aws_region](https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html)) or [configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) ([Using the AWS SDK for Java (Working with AWS Credentials)](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html)).

3. Consideration of [CloudWatch Logs quotas](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).　

| Resource | Default quota |
| :--- | :--- |
|Event size|  256 KB (maximum). This quota can't be changed. |
|PutLogEvents|  5 requests per second per log stream. Additional requests are throttled. This quota can't be changed. |
|Batch size| 1 MB (maximum). This quota can't be changed. |

4. Fixed the following bug
   log information loss by illegal order of conditions  
   (When messagesBatchSize is 10 and loggingEventsQueue size is greater than 11, then 12th log data is lost.)
    ```
    Incorrect conditions  
    while ((polledLoggingEvent = (LogEvent) loggingEventsQueue.poll()) != null && loggingEvents.size() <= messagesBatchSize)
    ↓
    Correct conditions
    while (loggingEvents.size() < messagesBatchSize && (polledLoggingEvent = (LogEvent) loggingEventsQueue.poll()) != null)
    ```
5. Addition important notes about MuleSoft CloudHub using multiple workers or multi-server system to README.md.

## Test Result <b>[^1],[^2]</b>
When 5 beyond requests per second per log stream, rate exceeded will error. So, In this program use retry processing to recover from rate excess errors.

### Before program modification
| No. | batch size | send count | req/s | 1st retry | 2nd retry | error | error rate(%) |
| :---: | ---: | ---: | ---: | :---: | :---: | ---: | ---: |
|1| 10 | 3,094 | 5.16  |-|-|52|1.68%|
|2| 100 | 3,118 | 5.20 |-|-|57|1.83%|
|3| 1,000 | 2,992 | 4.99 |-|-|33|1.10%|

### After program modification
| No. | batch size | send count | req/s [^3] | 1st retry | 2nd retry | error | error rate(%) |
| :---: | ---: | ---: |-----------:| ---: | ---: | ---: | ---: |
|1| 10 | 2,868 |       4.78 |26|2|0|0.00%|
|2| 100 | 2,756 |       4.59 |28|4|0|0.00%|
|3| 1,000 | 2,910 |       4.85 |22|5|0|0.00%|

[^1]: 10 minute continuous test.</b>  
[^2]: Test program is java client program that create 10 threads that output logs, and the logger send put event to Cloudwatch Logs in the Asia Pacific (Tokyo) via the Internet.</b>  
[^3]: Lower throughput is due to sleep time on retry. (retry sleep time: 5000msec)<b>
